### PR TITLE
Fix an intensive idiom

### DIFF
--- a/en/distributed.xml
+++ b/en/distributed.xml
@@ -270,7 +270,7 @@ esac
   <section xml:id="problemspassive">
     <title>Problems With Passive Checks</title>
 
-    <para>For all intensive purposes we can say that the central server is relying solely on passive checks for monitoring. The main problem
+    <para>For all intents and purposes we can say that the central server is relying solely on passive checks for monitoring. The main problem
     with relying completely on passive checks for monitoring is the fact that &name-icinga; must rely on something else to provide the
     monitoring data. What if the remote host that is sending in passive check results goes down or becomes unreachable? If &name-icinga;
     isn't actively checking the services on the host, how will it know that there is a problem?</para>


### PR DESCRIPTION
The phrase `for all intensive purposes` is a misheard idiom. The correct phrase is `for all intents and purposes`.

http://www.urbandictionary.com/define.php?term=For%20all%20intensive%20purposes
