### PR TITLE
Correct spelling of "servicestatustypes" parameter in example

### DIFF
--- a/de/cgiparams.xml
+++ b/de/cgiparams.xml
@@ -4480,7 +4480,7 @@
 
             <entry>1 - 31</entry>
 
-            <entry>servicestatustype=28 (services in problem state)</entry>
+            <entry>servicestatustypes=28 (services in problem state)</entry>
 
             <entry>Ein logisches ODER der Zustände: 1=Pending; 2=OK, 4=Warning; 8=Unknown; 16=Critical</entry>
           </row>

--- a/en/cgiparams.xml
+++ b/en/cgiparams.xml
@@ -4474,7 +4474,7 @@
 
             <entry>1 - 31</entry>
 
-            <entry>servicestatustype=28 (services in problem state)</entry>
+            <entry>servicestatustypes=28 (services in problem state)</entry>
 
             <entry>A boolean OR of the states: 1=Pending; 2=OK, 4=Warning; 8=Unknown; 16=Critical</entry>
           </row>


### PR DESCRIPTION
The parameter is spelled "servicestatustypes" in the "parameter" column, but "servicestatustype" in the "example" column.

Verified that "servicestatustypes" is the correct one.
